### PR TITLE
Fix style of folder structure in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ To get started with this project, follow these steps:
 ## Folder Structure
   The project folder structure is organized as follows:
 
+```
 E-react-frontend/
   ├── node_modules/           # Contains project dependencies (created when you run npm install)
   ├── public/                 # Publicly accessible files
@@ -68,7 +69,7 @@ E-react-frontend/
   ├── package-lock.json      # locks dependency versions for consistent installations
   ├── package.json           # Project metadata and dependencies
   └── README.md              # Documentation for your project
-
+```
 
   You can find the main application code in the src/ directory, and Redux-related code in   
   src/redux/.


### PR DESCRIPTION
The folder structure is not displayed correctly in Markdown. This commit adds it into a code block to fix it.

BEFORE:
![image](https://github.com/ottawa-ehospital/E-react-frontend/assets/13256681/5599f299-4ec6-49ca-8b5b-fc1fca7a6853)
AFTER:
![image](https://github.com/ottawa-ehospital/E-react-frontend/assets/13256681/f781cf0a-779f-4adb-b79f-7b1d16a47c81)
